### PR TITLE
Update API key and add current OI script

### DIFF
--- a/coinglass_scraper.py
+++ b/coinglass_scraper.py
@@ -17,7 +17,7 @@ import urllib.parse
 import urllib.request
 
 # Default API key used if no environment variable or command-line option is provided
-DEFAULT_API_KEY = "4f36824699cd4ebeb4b315b8b5927ac9"
+DEFAULT_API_KEY = "53b0a3236d8d4d2b9fff517c70c544ea"
 
 # Default base URL for the Coinglass open API v4
 BASE_URL = "https://open-api-v4.coinglass.com"

--- a/current_oi.py
+++ b/current_oi.py
@@ -1,0 +1,53 @@
+import argparse
+import csv
+import json
+import os
+import urllib.parse
+import urllib.request
+
+DEFAULT_API_KEY = os.getenv("COINGLASS_API_KEY", "53b0a3236d8d4d2b9fff517c70c544ea")
+BASE_URL = "https://open-api-v4.coinglass.com"
+
+
+def fetch(endpoint: str, params=None, api_key=None) -> dict:
+    url = urllib.parse.urljoin(BASE_URL, endpoint)
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url)
+    if api_key:
+        req.add_header("coinglassSecret", api_key)
+    with urllib.request.urlopen(req) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Request failed: {resp.status}")
+        return json.loads(resp.read().decode())
+
+
+def save_dict(data: dict, filepath: str) -> None:
+    if not data:
+        return
+    with open(filepath, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=data.keys())
+        writer.writeheader()
+        writer.writerow(data)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch current open interest from Coinglass")
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="Coinglass API key if required")
+    parser.add_argument("--symbol", default="BTC", help="Trading symbol, e.g. BTC")
+    parser.add_argument("--output", default="current_oi.csv", help="Output CSV file")
+    args = parser.parse_args()
+
+    data = fetch("/api/futures/open_interest", {"symbol": args.symbol}, api_key=args.api_key)
+    content = data.get("data") if isinstance(data, dict) else data
+    if isinstance(content, list):
+        if content:
+            content = content[0]
+        else:
+            content = {}
+    save_dict(content, args.output)
+    print(f"Saved current open interest to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set default API key to `53b0a3236d8d4d2b9fff517c70c544ea`
- add new `current_oi.py` helper for retrieving current open interest

## Testing
- `python coinglass_scraper.py --symbol BTC --output-dir data` *(fails: No route to host)*
- `python current_oi.py --symbol BTC --output current_oi.csv` *(fails: urlopen error)*