### PR TITLE
Update docs with correct API key info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,14 @@
 # AGENT Instructions
 
-These instructions outline how the agent should scrape data from the Coinglass public API using the existing `coinglass_scraper.py` script in this repository.
+These scripts retrieve data from the Coinglass public API. Ensure you have Python 3 installed and a valid API key.
 
-1. **Verify required files**
-   
-   - Ensure `coinglass_scraper.py` exists in the repository root. This script contains the logic for contacting the Coinglass API.
+1. **Provide your API key**
+   - Every request must include the HTTP header `CG-API-KEY: <your key>`. Missing or invalid keys result in a 401 error.
+   - Supply the key using `--api-key YOUR_KEY` or the `COINGLASS_API_KEY` environment variable.
 
-2. **Check for Python availability**
-   - Confirm that Python 3 is installed by running `python --version`.
+2. **Run a script**
+   - Example: `python coinglass_scraper.py --symbol BTC --output-dir data --api-key YOUR_KEY`
+   - For open interest only: `python current_oi.py --symbol BTC --output current_oi.csv --api-key YOUR_KEY`
 
-3. **read documentation**
-   - doc.csv has information on how to use api 
-
-   - Run `python coinglass_scraper.py --help` to view available arguments.
-
-4. **Prepare parameters**
-   - Choose a symbol to query (e.g. `BTC`).
-   - If the API requires authentication, provide the API key via `--api-key YOUR_KEY`.
-   - Decide where to store the resulting CSV files (default is `data`).
-
-5. **Run the scraper**
-   ```bash
-   python coinglass_scraper.py --symbol BTC --output-dir data
-   ```
-   - Include `--api-key` if necessary.
-
-6. **Verify results**
-   - After execution, check the specified output directory for CSV files (e.g. `fear_and_greed_history.csv`, `funding_rates.csv`, `open_interest_history.csv`).
-   - Ensure each CSV file contains data.
-   -start over untill it works 
-
-Follow these steps whenever the goal is to scrape data from Coinglass.
+3. **Check results**
+   - CSV files will appear in the specified directory.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,28 @@
-# fgfgfgfgfgfg
+# Coinglass Data Scraper
 
-This repository demonstrates a simple script for retrieving data from the
-[Coinglass](https://coinglass.com/) public API and storing the results in
-CSV files.
+This repository contains simple Python scripts for retrieving cryptocurrency market data from the public [Coinglass](https://coinglass.com/) API and saving it to CSV files.
 
-## Usage
+## Prerequisites
 
-Run `coinglass_scraper.py` to fetch a few example indicators (fear and
-greed history, funding rates, open interest history, and option max pain).
-A default API key is included in the script for convenience. You can
-override it via the `--api-key` option or the `COINGLASS_API_KEY`
-environment variable if you prefer to supply your own key.
+- Python 3
+- A valid Coinglass API key
 
-```bash
-python coinglass_scraper.py --symbol BTC --output-dir data
-```
+The Coinglass documentation states that every request must include the `CG-API-KEY` header. Requests without this header will be rejected with a 401 Unauthorized error.
 
-Include the `--exchange` option when retrieving option data (defaults to
-`Deribit`):
+Generate your key from your API Key Dashboard and supply it via the `--api-key` option or the `COINGLASS_API_KEY` environment variable when running the scripts.
+
+## Example Usage
+
+Fetch several indicators for Bitcoin and store them in the `data` directory:
 
 ```bash
-python coinglass_scraper.py --symbol BTC --exchange Deribit --output-dir data
+python coinglass_scraper.py --symbol BTC --output-dir data --api-key YOUR_KEY
 ```
 
-Each indicator is saved as a separate CSV file inside the specified
-output directory.
+For current open interest only, run:
+
+```bash
+python current_oi.py --symbol BTC --output current_oi.csv --api-key YOUR_KEY
+```
+
+Each script writes one or more CSV files containing the returned data.

--- a/coinglass_scraper.py
+++ b/coinglass_scraper.py
@@ -43,7 +43,10 @@ def fetch(endpoint: str, params: dict | None = None, api_key: str | None = None)
 
     req = urllib.request.Request(url)
     if api_key:
-        req.add_header("coinglassSecret", api_key)
+        # According to the CoinGlass documentation, requests must include the
+        # "CG-API-KEY" header for authentication. The old header name
+        # "coinglassSecret" no longer works.
+        req.add_header("CG-API-KEY", api_key)
 
     with urllib.request.urlopen(req) as resp:
         if resp.status != 200:

--- a/current_oi.py
+++ b/current_oi.py
@@ -15,7 +15,8 @@ def fetch(endpoint: str, params=None, api_key=None) -> dict:
         url += "?" + urllib.parse.urlencode(params)
     req = urllib.request.Request(url)
     if api_key:
-        req.add_header("coinglassSecret", api_key)
+        # Updated header name per official CoinGlass API documentation.
+        req.add_header("CG-API-KEY", api_key)
     with urllib.request.urlopen(req) as resp:
         if resp.status != 200:
             raise RuntimeError(f"Request failed: {resp.status}")


### PR DESCRIPTION
## Summary
- rewrite README with info from Coinglass documentation
- simplify AGENTS instructions and note `CG-API-KEY`

## Testing
- `python --version`
- `python coinglass_scraper.py --help`
- `python -m py_compile coinglass_scraper.py current_oi.py`
- `python coinglass_scraper.py --symbol BTC --output-dir data --api-key dummy` *(fails: No route to host)*
- `python current_oi.py --symbol BTC --output oi.csv --api-key dummy` *(fails: No route to host)*