### PR TITLE
Rewrite hobbyist endpoint fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ python current_oi.py --symbol BTC --output current_oi.csv --api-key YOUR_KEY
 ```
 
 Each script writes one or more CSV files containing the returned data.
+
+## Fetching All Hobbyist Endpoints
+
+`fetch_hobbyist_endpoints.py` reads the list of URLs in `endpoints.txt` and saves the
+response from each one to its own JSON file. This script is aimed at people who
+are not comfortable with coding. Simply run the command below and look in the
+output folder for the results.
+
+```bash
+python fetch_hobbyist_endpoints.py --api-key YOUR_KEY --output-dir data
+```
+
+The script creates the directory `data` if it does not already exist. Inside you
+will find a JSON file for every endpoint listed in `endpoints.txt`. If a request
+fails, the corresponding file will contain an error message instead of data.

--- a/endpoints.txt
+++ b/endpoints.txt
@@ -1,0 +1,11 @@
+title	link	description
+Coins Markets	https://open-api-v4.coinglass.com/api/futures/coins-markets	Performance metrics for all available futures coins
+Pairs Markets	https://open-api-v4.coinglass.com/api/futures/pairs-markets	Performance metrics for all available futures trading pairs
+Price History (OHLC)	https://open-api-v4.coinglass.com/api/futures/price/history	Historical open, high, low, close prices for cryptocurrencies
+Funding Rate History (OHLC)	https://open-api-v4.coinglass.com/api/futures/funding-rate/history	Funding rate data in candlestick format for futures trading pairs
+Open Interest Aggregated History	https://open-api-v4.coinglass.com/api/futures/open-interest/aggregated-history	Aggregated open interest data across exchanges in OHLC format
+Liquidation History	https://open-api-v4.coinglass.com/api/futures/liquidation/history	Historical long and short liquidations for a trading pair
+Spot Supported Coins	https://open-api-v4.coinglass.com/api/spot/supported-coins	List of supported spot coins
+Option Max Pain	https://open-api-v4.coinglass.com/api/option/max-pain	Max pain price for options
+Exchange Assets	https://open-api-v4.coinglass.com/api/exchange/assets	Asset holdings data for exchange wallets
+Bitcoin ETF List	https://open-api-v4.coinglass.com/api/etf/bitcoin/list	List of Bitcoin ETF status information

--- a/fetch_hobbyist_endpoints.py
+++ b/fetch_hobbyist_endpoints.py
@@ -1,0 +1,80 @@
+import argparse
+import json
+import os
+import urllib.request
+from pathlib import Path
+import re
+
+DEFAULT_API_KEY = os.getenv("COINGLASS_API_KEY", "53b0a3236d8d4d2b9fff517c70c544ea")
+
+ENDPOINT_FILE = "endpoints.txt"
+
+def fetch(url: str, api_key: str) -> dict:
+    """Fetch JSON data from the given URL."""
+    req = urllib.request.Request(url)
+    req.add_header("CG-API-KEY", api_key)
+    with urllib.request.urlopen(req) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Request failed: {resp.status}")
+        return json.loads(resp.read().decode())
+
+
+def load_endpoints(file_path: str):
+    """Yield (title, url) tuples from a tab-separated endpoint file."""
+    with open(file_path, "r") as f:
+        next(f)  # skip header
+        for line in f:
+            if not line.strip():
+                continue
+            title, url, _ = line.strip().split("\t")
+            yield title, url
+
+
+def slugify(text: str) -> str:
+    """Convert title to a safe file name."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch data from Hobbyist-accessible Coinglass endpoints"
+    )
+    parser.add_argument(
+        "--api-key",
+        default=DEFAULT_API_KEY,
+        help="Your Coinglass API key",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="hobbyist_output",
+        help="Directory to store JSON files",
+    )
+    parser.add_argument(
+        "--endpoints",
+        default=ENDPOINT_FILE,
+        help="Path to endpoints.txt",
+    )
+
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for title, url in load_endpoints(args.endpoints):
+        file_name = slugify(title) + ".json"
+        path = out_dir / file_name
+        try:
+            data = fetch(url, args.api_key)
+            with open(path, "w") as f:
+                json.dump(data, f, indent=2)
+            print(f"Fetched {title}")
+        except Exception as exc:
+            with open(path, "w") as f:
+                json.dump({"error": str(exc)}, f, indent=2)
+            print(f"Failed to fetch {title}: {exc}")
+
+    print(f"Saved endpoint data to {out_dir}/")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update `fetch_hobbyist_endpoints.py` to read `endpoints.txt` and save each response in its own JSON file
- create `endpoints.txt` with sample Hobbyist URLs
- document the new workflow in the README

## Testing
- `python -m py_compile fetch_hobbyist_endpoints.py`
- `python fetch_hobbyist_endpoints.py --help`
