### PR TITLE
Improve hobbyist endpoint fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,19 @@ Each script writes one or more CSV files containing the returned data.
 
 ## Fetching All Hobbyist Endpoints
 
-`fetch_hobbyist_endpoints.py` reads the list of URLs in `endpoints.txt` and saves the
-response from each one to its own JSON file. This script is aimed at people who
-are not comfortable with coding. Simply run the command below and look in the
-output folder for the results.
+`fetch_hobbyist_endpoints.py` reads the list of URLs in `endpoints_merged.txt` (or
+any file you provide with `--endpoints`) and saves the response from each one to
+a file. By default the script tries to pick the best file type for each piece of
+data (CSV for tables, text for plain messages). You can override this behaviour
+with the `--format` option and choose `csv`, `json`, or `txt`.
 
 ```bash
 python fetch_hobbyist_endpoints.py --api-key YOUR_KEY --output-dir data
 ```
 
 The script creates the directory `data` if it does not already exist. Inside you
-will find a JSON file for every endpoint listed in `endpoints.txt`. If a request
-fails, the corresponding file will contain an error message instead of data.
+will find files in the chosen format (CSV, JSON, or plain text). If a request
+fails, the corresponding file will contain the error message instead of data.
 
 ## Merging Endpoint Lists
 


### PR DESCRIPTION
## Summary
- add `--format` option to `fetch_hobbyist_endpoints.py`
- store output as CSV, JSON, or text depending on user choice
- document new option in README

## Testing
- `python -m py_compile fetch_hobbyist_endpoints.py coinglass_scraper.py current_oi.py`
- `python fetch_hobbyist_endpoints.py --help`