### PR TITLE
Add per-category fetch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ The script creates the directory `data` if it does not already exist. Inside you
 will find files in the chosen format (CSV, JSON, or plain text). If a request
 fails, the corresponding file will contain the error message instead of data.
 
+## Fetching Endpoints by Category
+
+For convenience there is a ready-made script for every API category. Each file
+is named `fetch_<category>.py` where `<category>` matches the part after
+`/api/` in the URLs from `endpoints.txt`. For example, to download all endpoints
+under the `futures` category run:
+
+```bash
+python fetch_futures.py --api-key YOUR_KEY --output-dir my_data
+```
+
+The script automatically sets the category for you, so the only options you need
+are the API key and an output directory. Similar files exist for other
+categories such as `spot`, `etf`, and `exchange`. Check the repository for the
+available `fetch_*.py` scripts. Internally these wrappers call
+`fetch_by_category.py`.
+
+If the list of endpoints changes, run `python generate_category_scripts.py` to
+recreate the wrapper files.
+
 ## Merging Endpoint Lists
 
 If you have two different files of API URLs, such as `endpoints.txt` and

--- a/fetch_bitfinex_margin_long_short.py
+++ b/fetch_bitfinex_margin_long_short.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'bitfinex-margin-long-short']
+    fetch_by_category.main()

--- a/fetch_borrow_interest_rate.py
+++ b/fetch_borrow_interest_rate.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'borrow-interest-rate']
+    fetch_by_category.main()

--- a/fetch_bull_market_peak_indicator.py
+++ b/fetch_bull_market_peak_indicator.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'bull-market-peak-indicator']
+    fetch_by_category.main()

--- a/fetch_by_category.py
+++ b/fetch_by_category.py
@@ -1,0 +1,77 @@
+import argparse
+import json
+import os
+import urllib.request
+from pathlib import Path
+import re
+
+DEFAULT_API_KEY = os.getenv("COINGLASS_API_KEY", "53b0a3236d8d4d2b9fff517c70c544ea")
+ENDPOINT_FILE = "endpoints.txt"
+
+
+def fetch(url: str, api_key: str) -> dict:
+    """Fetch JSON data from the given URL."""
+    req = urllib.request.Request(url)
+    req.add_header("CG-API-KEY", api_key)
+    with urllib.request.urlopen(req) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Request failed: {resp.status}")
+        return json.loads(resp.read().decode())
+
+
+def load_endpoints(file_path: str):
+    """Yield (title, url, category) tuples from the endpoint file."""
+    with open(file_path, "r") as f:
+        next(f)  # skip header
+        for line in f:
+            if not line.strip():
+                continue
+            title, url, _ = line.strip().split("\t")
+            # Category inferred from URL path e.g. /api/futures/...
+            # Taking the part after '/api/'
+            parts = url.split("/api/")
+            category = parts[1].split("/")[0] if len(parts) > 1 else "misc"
+            yield title, url, category
+
+
+def slugify(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def save_json(data: dict, base_path: Path) -> None:
+    out_file = base_path.with_suffix(".json")
+    with open(out_file, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch Coinglass endpoints for a specific category"
+    )
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="Your Coinglass API key")
+    parser.add_argument("--output-dir", default="category_output", help="Directory to store results")
+    parser.add_argument("--endpoints", default=ENDPOINT_FILE, help="Path to endpoints list")
+    parser.add_argument("--category", required=True, help="Category to fetch (e.g. futures, spot)")
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for title, url, cat in load_endpoints(args.endpoints):
+        if cat != args.category:
+            continue
+        file_base = out_dir / slugify(title)
+        try:
+            data = fetch(url, args.api_key)
+            save_json(data, file_base)
+            print(f"Fetched {title}")
+        except Exception as exc:
+            with open(file_base.with_suffix(".txt"), "w") as f:
+                f.write(str(exc))
+            print(f"Failed to fetch {title}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fetch_coinbase_premium_index.py
+++ b/fetch_coinbase_premium_index.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'coinbase-premium-index']
+    fetch_by_category.main()

--- a/fetch_etf.py
+++ b/fetch_etf.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'etf']
+    fetch_by_category.main()

--- a/fetch_exchange.py
+++ b/fetch_exchange.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'exchange']
+    fetch_by_category.main()

--- a/fetch_futures.py
+++ b/fetch_futures.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'futures']
+    fetch_by_category.main()

--- a/fetch_grayscale.py
+++ b/fetch_grayscale.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'grayscale']
+    fetch_by_category.main()

--- a/fetch_hk_etf.py
+++ b/fetch_hk_etf.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'hk-etf']
+    fetch_by_category.main()

--- a/fetch_hyperliquid.py
+++ b/fetch_hyperliquid.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'hyperliquid']
+    fetch_by_category.main()

--- a/fetch_index.py
+++ b/fetch_index.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'index']
+    fetch_by_category.main()

--- a/fetch_option.py
+++ b/fetch_option.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'option']
+    fetch_by_category.main()

--- a/fetch_spot.py
+++ b/fetch_spot.py
@@ -1,0 +1,7 @@
+import sys
+import fetch_by_category
+
+if __name__ == "__main__":
+    if '--category' not in sys.argv:
+        sys.argv += ['--category', 'spot']
+    fetch_by_category.main()

--- a/generate_category_scripts.py
+++ b/generate_category_scripts.py
@@ -1,0 +1,50 @@
+import re
+from pathlib import Path
+
+ENDPOINT_FILE = "endpoints.txt"
+
+
+def slugify(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def get_categories() -> set[str]:
+    categories = set()
+    with open(ENDPOINT_FILE) as f:
+        next(f)
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                _, url, _ = line.strip().split("\t")
+            except ValueError:
+                continue
+            parts = url.split("/api/")
+            cat = parts[1].split("/")[0] if len(parts) > 1 else "misc"
+            categories.add(cat)
+    return categories
+
+
+def create_script(category: str) -> None:
+    slug = slugify(category)
+    path = Path(f"fetch_{slug}.py")
+    path.write_text(
+        "import sys\n"
+        "import fetch_by_category\n\n"
+        "if __name__ == \"__main__\":\n"
+        "    if '--category' not in sys.argv:\n"
+        f"        sys.argv += ['--category', '{category}']\n"
+        "    fetch_by_category.main()\n"
+    )
+    print(f"Created {path}")
+
+
+def main():
+    for cat in sorted(get_categories()):
+        create_script(cat)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate `fetch_<category>.py` wrappers for each API category
- note how to use these scripts in the README
- add a helper script `generate_category_scripts.py`

## Testing
- `python -m py_compile fetch_hobbyist_endpoints.py fetch_by_category.py generate_category_scripts.py fetch_*.py`
