### PR TITLE
Remove hardcoded API keys and add config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ pip install -r requirements.txt
 
 This command downloads the dependencies used in the example scripts.
 
+## Setting Your API Key
+
+1. Copy the file `config.env` and open it in a text editor.
+2. Replace `YOUR_API_KEY` with the key you received from Coinglass.
+3. In the terminal run `source config.env` to load the variable.
+
+Alternatively you can supply the key when running a script using the `--api-key` option.
+
 ✅ Example Usage
 
 curl
@@ -55,13 +63,15 @@ Status Code Description
 Fetch several indicators for Bitcoin and store them in the `data` directory:
 
 ```bash
-python coinglass_scraper.py --symbol BTC --output-dir data --api-key YOUR_KEY
+source config.env  # sets COINGLASS_API_KEY
+python coinglass_scraper.py --symbol BTC --output-dir data
 ```
 
 For current open interest only, run:
 
 ```bash
-python current_oi.py --symbol BTC --output current_oi.csv --api-key YOUR_KEY
+source config.env
+python current_oi.py --symbol BTC --output current_oi.csv
 ```
 
 Each script writes one or more CSV files containing the returned data.
@@ -75,7 +85,8 @@ data (CSV for tables, text for plain messages). You can override this behaviour
 with the `--format` option and choose `csv`, `json`, or `txt`.
 
 ```bash
-python fetch_hobbyist_endpoints.py --api-key YOUR_KEY --output-dir data
+source config.env
+python fetch_hobbyist_endpoints.py --output-dir data
 ```
 
 The script creates the directory `data` if it does not already exist. Inside you
@@ -90,7 +101,8 @@ is named `fetch_<category>.py` where `<category>` matches the part after
 under the `futures` category run:
 
 ```bash
-python fetch_futures.py --api-key YOUR_KEY --output-dir my_data
+source config.env
+python fetch_futures.py --output-dir my_data
 ```
 
 The script automatically sets the category for you, so the only options you need

--- a/coinglass_scraper.py
+++ b/coinglass_scraper.py
@@ -16,8 +16,6 @@ import os
 import urllib.parse
 import urllib.request
 
-# Default API key used if no environment variable or command-line option is provided
-DEFAULT_API_KEY = "53b0a3236d8d4d2b9fff517c70c544ea"
 
 # Default base URL for the Coinglass open API v4
 BASE_URL = "https://open-api-v4.coinglass.com"
@@ -67,12 +65,16 @@ def save_list_of_dicts(items: list[dict], filepath: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Scrape data from Coinglass and store as CSV files")
-    default_key = os.getenv("COINGLASS_API_KEY", DEFAULT_API_KEY)
-    parser.add_argument("--api-key", help="Coinglass API key if required", default=default_key)
+    env_key = os.getenv("COINGLASS_API_KEY")
+    parser.add_argument("--api-key", help="Coinglass API key")
     parser.add_argument("--exchange", help="Exchange for option data", default="Deribit")
     parser.add_argument("--symbol", help="Symbol to query (e.g. BTC)", default="BTC")
     parser.add_argument("--output-dir", help="Directory to store CSV files", default="data")
     args = parser.parse_args()
+
+    api_key = args.api_key or env_key
+    if not api_key:
+        parser.error("An API key is required. Use --api-key or set COINGLASS_API_KEY.")
 
     os.makedirs(args.output_dir, exist_ok=True)
 
@@ -80,7 +82,7 @@ def main() -> None:
         endpoint = meta["path"]
         params = {p: getattr(args, p) for p in meta.get("params", [])}
         try:
-            data = fetch(endpoint, params=params, api_key=args.api_key)
+            data = fetch(endpoint, params=params, api_key=api_key)
             if isinstance(data, dict):
                 content = data.get("data") or data
             else:

--- a/config.env
+++ b/config.env
@@ -1,0 +1,2 @@
+# Copy this file to config.env and replace YOUR_API_KEY with your actual key
+COINGLASS_API_KEY=YOUR_API_KEY

--- a/current_oi.py
+++ b/current_oi.py
@@ -4,8 +4,6 @@ import json
 import os
 import urllib.parse
 import urllib.request
-
-DEFAULT_API_KEY = os.getenv("COINGLASS_API_KEY", "53b0a3236d8d4d2b9fff517c70c544ea")
 BASE_URL = "https://open-api-v4.coinglass.com"
 
 
@@ -34,12 +32,17 @@ def save_dict(data: dict, filepath: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch current open interest from Coinglass")
-    parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="Coinglass API key if required")
+    env_key = os.getenv("COINGLASS_API_KEY")
+    parser.add_argument("--api-key", help="Coinglass API key")
     parser.add_argument("--symbol", default="BTC", help="Trading symbol, e.g. BTC")
     parser.add_argument("--output", default="current_oi.csv", help="Output CSV file")
     args = parser.parse_args()
 
-    data = fetch("/api/futures/open_interest", {"symbol": args.symbol}, api_key=args.api_key)
+    api_key = args.api_key or env_key
+    if not api_key:
+        parser.error("An API key is required. Use --api-key or set COINGLASS_API_KEY.")
+
+    data = fetch("/api/futures/open_interest", {"symbol": args.symbol}, api_key=api_key)
     content = data.get("data") if isinstance(data, dict) else data
     if isinstance(content, list):
         if content:

--- a/example.py
+++ b/example.py
@@ -1,11 +1,16 @@
 # get supported coins
 import requests
+import os
 
 url = "https://open-api-v4.coinglass.com/api/futures/supported-coins"
 
+api_key = os.getenv("COINGLASS_API_KEY")
+if not api_key:
+    raise SystemExit("Please set the COINGLASS_API_KEY environment variable")
+
 headers = {
     "accept": "application/json",
-    "CG-API-KEY": "53b0a3236d8d4d2b9fff517c70c544ea",
+    "CG-API-KEY": api_key,
 }
 
 response = requests.get(url, headers=headers)

--- a/fetch_by_category.py
+++ b/fetch_by_category.py
@@ -5,7 +5,7 @@ import urllib.request
 from pathlib import Path
 import re
 
-DEFAULT_API_KEY = os.getenv("COINGLASS_API_KEY", "53b0a3236d8d4d2b9fff517c70c544ea")
+DEFAULT_API_KEY = None
 ENDPOINT_FILE = "endpoints.txt"
 
 
@@ -50,11 +50,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Fetch Coinglass endpoints for a specific category"
     )
-    parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="Your Coinglass API key")
+    env_key = os.getenv("COINGLASS_API_KEY")
+    parser.add_argument("--api-key", help="Your Coinglass API key")
     parser.add_argument("--output-dir", default="category_output", help="Directory to store results")
     parser.add_argument("--endpoints", default=ENDPOINT_FILE, help="Path to endpoints list")
     parser.add_argument("--category", required=True, help="Category to fetch (e.g. futures, spot)")
     args = parser.parse_args()
+
+    api_key = args.api_key or env_key
+    if not api_key:
+        parser.error("An API key is required. Use --api-key or set COINGLASS_API_KEY.")
 
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -64,7 +69,7 @@ def main() -> None:
             continue
         file_base = out_dir / slugify(title)
         try:
-            data = fetch(url, args.api_key)
+            data = fetch(url, api_key)
             save_json(data, file_base)
             print(f"Fetched {title}")
         except Exception as exc:

--- a/fetch_hobbyist_endpoints.py
+++ b/fetch_hobbyist_endpoints.py
@@ -6,7 +6,7 @@ import urllib.request
 from pathlib import Path
 import re
 
-DEFAULT_API_KEY = os.getenv("COINGLASS_API_KEY", "53b0a3236d8d4d2b9fff517c70c544ea")
+DEFAULT_API_KEY = None
 
 # Default list of public endpoints to fetch. Update this path if you
 # maintain your own file of URLs.
@@ -94,9 +94,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Fetch data from Hobbyist-accessible Coinglass endpoints"
     )
+    env_key = os.getenv("COINGLASS_API_KEY")
     parser.add_argument(
         "--api-key",
-        default=DEFAULT_API_KEY,
         help="Your Coinglass API key",
     )
     parser.add_argument(
@@ -118,13 +118,17 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    api_key = args.api_key or env_key
+    if not api_key:
+        parser.error("An API key is required. Use --api-key or set COINGLASS_API_KEY.")
+
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     for title, url in load_endpoints(args.endpoints):
         file_base = out_dir / slugify(title)
         try:
-            data = fetch(url, args.api_key)
+            data = fetch(url, api_key)
             save_response(data, file_base, args.format)
             print(f"Fetched {title}")
         except Exception as exc:

--- a/wss.js
+++ b/wss.js
@@ -1,3 +1,14 @@
-const wssWebSocket = new WebSocket("wss://open-ws.coinglass.com/ws-api?cg-api-key=53b0a3236d8d4d2b9fff517c70c544ea");
-console.log(wssWebSocket.url); // 'wss://websocket.example.org'
+const argIndex = process.argv.indexOf('--api-key');
+let apiKey = process.env.COINGLASS_API_KEY;
+if (argIndex !== -1 && process.argv.length > argIndex + 1) {
+  apiKey = process.argv[argIndex + 1];
+}
+
+if (!apiKey) {
+  console.error('An API key is required. Use --api-key or set COINGLASS_API_KEY.');
+  process.exit(1);
+}
+
+const wssWebSocket = new WebSocket(`wss://open-ws.coinglass.com/ws-api?cg-api-key=${apiKey}`);
+console.log(wssWebSocket.url); // 'wss://open-ws.coinglass.com/ws-api?cg-api-key=***'
 wssWebSocket.close();


### PR DESCRIPTION
## Summary
- remove default API keys from example scripts
- require `--api-key` or `COINGLASS_API_KEY` in scraper, open interest tool and websocket example
- update helper scripts to read API key from CLI or environment
- add `config.env` template and explain how to use it
- document using `config.env` in README

## Testing
- `python -m py_compile coinglass_scraper.py current_oi.py fetch_by_category.py fetch_hobbyist_endpoints.py example.py`