### PR TITLE
Refactor API helpers and sanitize example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ pip install -r requirements.txt
 
 This command downloads the dependencies used in the example scripts.
 
+All Python files rely on a small helper in `api_utils.py` which sends the
+authenticated HTTP requests. You don't need to edit this file—just keep it in
+the same folder as the other scripts.
+
 ## Setting Your API Key
 
 1. Copy the file `config.env` and open it in a text editor.

--- a/api_utils.py
+++ b/api_utils.py
@@ -1,0 +1,20 @@
+import urllib.parse
+import requests
+
+BASE_URL = "https://open-api-v4.coinglass.com"
+
+
+def fetch(endpoint: str, params: dict | None = None, api_key: str | None = None) -> dict:
+    """Return JSON data from the given Coinglass endpoint."""
+    url = urllib.parse.urljoin(BASE_URL, endpoint)
+    headers = {}
+    if api_key:
+        headers["CG-API-KEY"] = api_key
+    resp = requests.get(url, headers=headers, params=params)
+    if resp.status_code == 401:
+        raise RuntimeError("Unauthorized. Check your API key.")
+    if resp.status_code == 429:
+        raise RuntimeError("Rate limit exceeded. Try again later.")
+    if resp.status_code != 200:
+        raise RuntimeError(f"Request failed: {resp.status_code}")
+    return resp.json()

--- a/coinglass_scraper.py
+++ b/coinglass_scraper.py
@@ -13,12 +13,9 @@ import argparse
 import csv
 import json
 import os
-import urllib.parse
-import requests
+from api_utils import fetch
 
 
-# Default base URL for the Coinglass open API v4
-BASE_URL = "https://open-api-v4.coinglass.com"
 
 # Example endpoints. Additional endpoints can be added to this mapping.
 # Each entry contains the endpoint path and a list of required parameters.
@@ -33,20 +30,6 @@ ENDPOINTS = {
 }
 
 
-def fetch(endpoint: str, params: dict | None = None, api_key: str | None = None) -> dict:
-    """Fetch JSON data from the given Coinglass endpoint."""
-    url = urllib.parse.urljoin(BASE_URL, endpoint)
-    headers = {}
-    if api_key:
-        # According to the CoinGlass documentation, requests must include the
-        # "CG-API-KEY" header for authentication. The old header name
-        # "coinglassSecret" no longer works.
-        headers["CG-API-KEY"] = api_key
-
-    resp = requests.get(url, headers=headers, params=params)
-    if resp.status_code != 200:
-        raise RuntimeError(f"Request failed: {resp.status_code}")
-    return resp.json()
 
 
 def save_list_of_dicts(items: list[dict], filepath: str) -> None:

--- a/config.env
+++ b/config.env
@@ -1,2 +1,2 @@
 # Copy this file to config.env and replace YOUR_API_KEY with your actual key
-COINGLASS_API_KEY="53b0a3236d8d4d2b9fff517c70c544ea"
+COINGLASS_API_KEY="YOUR_API_KEY"

--- a/current_oi.py
+++ b/current_oi.py
@@ -1,24 +1,10 @@
 import argparse
-import requests
 import csv
-import json
 import os
-import urllib.parse
-import urllib.request
-import requests
 
-BASE_URL = "https://open-api-v4.coinglass.com"
+from api_utils import fetch
 
 
-def fetch(endpoint: str, params=None, api_key=None) -> dict:
-    url = urllib.parse.urljoin(BASE_URL, endpoint)
-    headers = {}
-    if api_key:
-        headers["CG-API-KEY"] = api_key
-    resp = requests.get(url, headers=headers, params=params)
-    if resp.status_code != 200:
-        raise RuntimeError(f"Request failed: {resp.status_code}")
-    return resp.json()
 
 
 def save_dict(data: dict, filepath: str) -> None:

--- a/example.py
+++ b/example.py
@@ -1,20 +1,12 @@
 # get supported coins
-import requests
 import os
+from api_utils import fetch
 
-url = "https://open-api-v4.coinglass.com/api/futures/supported-coins"
+url = "/api/futures/supported-coins"
 
 api_key = os.getenv("COINGLASS_API_KEY")
 if not api_key:
     raise SystemExit("Please set the COINGLASS_API_KEY environment variable")
 
-headers = {
-    "accept": "application/json",
-    "CG-API-KEY": api_key,
-}
-
-response = requests.get(url, headers=headers)
-if response.status_code != 200:
-    print(f"Request failed: {response.status_code}")
-else:
-    print(response.text)
+data = fetch(url, api_key=api_key)
+print(data)

--- a/fetch_by_category.py
+++ b/fetch_by_category.py
@@ -1,21 +1,15 @@
 import argparse
 import json
 import os
-import requests
 from pathlib import Path
 import re
+
+from api_utils import fetch
 
 DEFAULT_API_KEY = None
 ENDPOINT_FILE = "endpoints.txt"
 
 
-def fetch(url: str, api_key: str) -> dict:
-    """Fetch JSON data from the given URL."""
-    headers = {"CG-API-KEY": api_key}
-    resp = requests.get(url, headers=headers)
-    if resp.status_code != 200:
-        raise RuntimeError(f"Request failed: {resp.status_code}")
-    return resp.json()
 
 
 def load_endpoints(file_path: str):

--- a/fetch_hobbyist_endpoints.py
+++ b/fetch_hobbyist_endpoints.py
@@ -2,9 +2,10 @@ import argparse
 import csv
 import json
 import os
-import requests
 from pathlib import Path
 import re
+
+from api_utils import fetch
 
 DEFAULT_API_KEY = None
 
@@ -12,13 +13,6 @@ DEFAULT_API_KEY = None
 # maintain your own file of URLs.
 ENDPOINT_FILE = "endpoints.txt"
 
-def fetch(url: str, api_key: str) -> dict:
-    """Fetch JSON data from the given URL."""
-    headers = {"CG-API-KEY": api_key}
-    resp = requests.get(url, headers=headers)
-    if resp.status_code != 200:
-        raise RuntimeError(f"Request failed: {resp.status_code}")
-    return resp.json()
 
 
 def load_endpoints(file_path: str):


### PR DESCRIPTION
## Summary
- centralize API requests in new `api_utils.fetch`
- refactor scripts to use the shared helper
- remove the embedded API key from `config.env`
- clarify README with note about the helper module

## Testing
- `python -m py_compile api_utils.py coinglass_scraper.py current_oi.py fetch_by_category.py fetch_hobbyist_endpoints.py example.py`